### PR TITLE
feat(canvas-player): add `delay` option to play()

### DIFF
--- a/packages/canvas-player/src/CanvasPlayer.ts
+++ b/packages/canvas-player/src/CanvasPlayer.ts
@@ -26,6 +26,10 @@ export interface PlayOptions {
   mode?: PlayMode;
   onUpdated?: PlayListener;
   onEnded?: PlayListener;
+  /**
+   * 播放延迟时间，单位毫秒
+   */
+  delay?: number;
 }
 
 export class CanvasPlayer {
@@ -35,7 +39,7 @@ export class CanvasPlayer {
     canvas: HTMLCanvasElement,
     urls: string[],
     options: CanvasPlayerOptions = {},
-  ) {
+  ): CanvasPlayer {
     return new CanvasPlayer(
       canvas,
       ImageSequence.createFromURLs(urls),
@@ -51,10 +55,17 @@ export class CanvasPlayer {
   private frameRequest?: number = undefined;
   private sizeInitialized: boolean;
 
-  private last: number;
-  private cur: number;
-
-  private playInterval?: number;
+  private readonly playingState: {
+    cur: number;
+    last: number;
+    options: Partial<PlayOptions>;
+    interval?: number;
+    delayedTimeout?: number;
+  } = {
+    cur: -1,
+    last: -1,
+    options: {},
+  };
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -77,8 +88,6 @@ export class CanvasPlayer {
     this.shouldClear = shouldClear;
 
     this.sizeInitialized = !fitImageSize;
-    this.last = -1;
-    this.cur = -1;
 
     if (!alpha) {
       ctx.fillStyle = backgroundColor;
@@ -95,55 +104,96 @@ export class CanvasPlayer {
     }
   }
 
-  load() {
+  /**
+   * 加载序列帧
+   */
+  load(): Promise<HTMLImageElement[]> {
     return this.sequence.load();
   }
 
-  async seek(i: number, { draw = true }: SeekOptions = {}) {
-    this.cur = i;
+  /**
+   * 跳转到指定帧
+   * @param i
+   * @param param1
+   */
+  async seek(i: number, { draw = true }: SeekOptions = {}): Promise<void> {
+    this.playingState.cur = i;
     if (draw) {
       return this.drawCurrentFrame();
     }
   }
-  async seekPercent(p: number, options: SeekOptions) {
+  /**
+   * 按百分比跳转到指定帧
+   * @param p
+   * @param options
+   */
+  async seekPercent(p: number, options: SeekOptions): Promise<void> {
     return this.seek(Math.round(p * (this.sequence.length - 1)), options);
   }
 
-  get playing() {
-    return this.playInterval !== undefined;
+  /**
+   * 是否在播放
+   */
+  get playing(): boolean {
+    return this.playingState.interval !== undefined;
   }
 
-  pause() {
-    window.clearInterval(this.playInterval);
-    this.playInterval = undefined;
+  /**
+   * 是否未播放：`!this.playing`
+   */
+  get paused(): boolean {
+    return !this.playing;
   }
 
-  async play({
-    fps = 24,
-    mode = PlayMode.Normal,
-    waitOnLoading = true,
-    onUpdated,
-    onEnded,
-  }: PlayOptions = {}) {
-    if (this.playInterval !== undefined) {
-      window.clearInterval(this.playInterval);
+  /**
+   * 暂停播放
+   */
+  pause(): void {
+    window.clearInterval(this.playingState.interval);
+    this.playingState.interval = undefined;
+  }
+
+  /**
+   * 播放序列帧
+   * 传入的 options 会被记住，下次以相同的参数调用可以省略
+   * @param options
+   */
+  async play(options: PlayOptions = this.playingState.options): Promise<void> {
+    const { playingState } = this;
+
+    if (playingState.interval !== undefined) {
+      window.clearInterval(playingState.interval);
+    }
+    if (playingState.delayedTimeout !== undefined) {
+      window.clearTimeout(playingState.delayedTimeout);
+      playingState.delayedTimeout = undefined;
     }
 
-    let direction = mode === PlayMode.Reverse ? -1 : 1;
+    playingState.options = options;
+    const {
+      fps = 24,
+      mode = PlayMode.Normal,
+      waitOnLoading = true,
+      onUpdated,
+      onEnded,
+      delay,
+    } = options;
+
+    let reversed = mode === PlayMode.Reverse;
 
     let waiting = false;
-    const play = () => {
+    const play = (isDelayed = false) => {
       if (waiting) {
         if (CanvasPlayer.DEBUG) {
           console.log(
-            `Waiting to play ${this.cur}th:`,
-            this.sequence.getImageAt(this.cur),
+            `Waiting to play ${playingState.cur}th:`,
+            this.sequence.getImageAt(playingState.cur),
           );
         }
         return;
       }
 
-      const emitUpdate = (i: number) => {
+      const callOnUpdated = (i: number) => {
         if (onUpdated) {
           window.setTimeout(() => onUpdated({ i }), 0);
         }
@@ -153,52 +203,74 @@ export class CanvasPlayer {
           waiting = true;
           this.seek(i).then(() => {
             waiting = false;
-            emitUpdate(i);
+            callOnUpdated(i);
           });
         } else {
           this.seek(i).catch(console.error);
-          emitUpdate(i);
+          callOnUpdated(i);
         }
       };
 
-      const next = this.cur + direction;
-      const out = next >= this.sequence.length || next < 0;
-      if (!out) {
+      const next = playingState.cur + (reversed ? -1 : 1);
+      const outOfRange = next >= this.sequence.length || next < 0;
+      if (!outOfRange) {
         return update(next);
       }
-      switch (mode) {
-        case PlayMode.Loop:
-          update(0);
-          break;
-        case PlayMode.Alternate:
-          direction = -direction;
-          update(direction > 0 ? 0 : this.sequence.length - 1);
-          break;
-        default:
+      // 超出有效范围了
+
+      if (mode === PlayMode.Loop || mode === PlayMode.Alternate) {
+        if (mode === PlayMode.Alternate) {
+          // 翻转播放方向
+          reversed = !reversed;
+        }
+
+        // 下一帧应该为相应方向下的第一帧
+        const next = !reversed ? 0 : this.sequence.length - 1;
+
+        if (delay && delay > 0 && !isDelayed) {
+          // 需要延迟再重复，先暂停
           this.pause();
-          if (onEnded) {
-            window.setTimeout(() => onEnded({ i: next }), 0);
-          }
-          break;
+
+          playingState.delayedTimeout = window.setTimeout(() => {
+            play(true);
+            playingState.interval = window.setInterval(
+              () => play(),
+              1000 / fps,
+            );
+            if (playingState.delayedTimeout) {
+              window.clearTimeout(playingState.delayedTimeout);
+              playingState.delayedTimeout = undefined;
+            }
+          }, delay);
+          return;
+        }
+
+        update(next);
+      } else {
+        this.pause();
+        if (onEnded) {
+          window.setTimeout(() => onEnded({ i: next }), 0);
+        }
       }
     };
-    this.playInterval = window.setInterval(play, 1000 / fps);
+    playingState.interval = window.setInterval(() => play(), 1000 / fps);
   }
 
   private async drawCurrentFrame() {
-    if (this.cur === this.last) {
+    const { playingState } = this;
+    if (playingState.cur === playingState.last) {
       return;
     }
-    const image = this.sequence.getImageAt(this.cur);
+    const image = this.sequence.getImageAt(playingState.cur);
     if (!image) {
       return;
     }
 
-    this.last = this.cur;
+    playingState.last = playingState.cur;
     if (image instanceof window.Image) {
       return this.drawImage(image);
     }
-    const waitingAt = this.cur;
+    const waitingAt = playingState.cur;
     if (CanvasPlayer.DEBUG) {
       console.warn(
         `Try to draw the ${waitingAt}th image unloaded:`,

--- a/packages/canvas-player/src/ImageSequence.ts
+++ b/packages/canvas-player/src/ImageSequence.ts
@@ -1,5 +1,5 @@
 export class ImageSequence {
-  static createFromURLs(urls: string[]) {
+  static createFromURLs(urls: string[]): ImageSequence {
     const promises: Array<Promise<HTMLImageElement> | undefined> = urls.map(
       () => undefined,
     );
@@ -50,14 +50,14 @@ export class ImageSequence {
 
   async load(): Promise<HTMLImageElement[]>;
   async load(i: number): Promise<HTMLImageElement>;
-  async load(i?: number) {
+  async load(i?: number): Promise<HTMLImageElement[] | HTMLImageElement> {
     if (i === undefined) {
       return Promise.all(this.images.map((_, i) => this.loadAt(i)));
     }
     return this.loadAt(i);
   }
 
-  getImageAt(i: number) {
+  getImageAt(i: number): HTMLImageElement | Promise<HTMLImageElement> {
     return this.imagesLoaded[i] || this.loadAt(i);
   }
 


### PR DESCRIPTION
## CanvasPlayer
- `play(options)`的`options`中添加`delay`参数，在`Alternate`和`Loop`模式下可以通过该值设置循环间的延迟
- `play(options)`的`options`会被记住，下次以相同的参数调用时可以省略